### PR TITLE
Use a unique color when adding a new counter

### DIFF
--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
@@ -29,6 +29,7 @@ class CountersViewModel extends AndroidViewModel {
     private final LiveData<List<Counter>> counters;
     private final String[] colors;
     private int listSize;
+    private int nextCounterColor;
 
     CountersViewModel(Application application, CountersRepository countersRepository) {
         super(application);
@@ -46,7 +47,7 @@ class CountersViewModel extends AndroidViewModel {
     }
 
     void addCounter() {
-        repository.createCounter(String.valueOf(listSize + 1), getNextColor())
+        repository.createCounter(String.valueOf(nextCounterColor + 1), getNextColor())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeOn(Schedulers.io())
                 .subscribe(new CompletableObserver() {
@@ -64,6 +65,7 @@ class CountersViewModel extends AndroidViewModel {
 
                     }
                 });
+        nextCounterColor++;
     }
 
     void decreaseCounter(Counter counter) {
@@ -160,9 +162,9 @@ class CountersViewModel extends AndroidViewModel {
 
     void removeAll() {
         List<Counter> counterList = counters.getValue();
-        if(counterList != null){
-            for(int i = 0; i < counterList.size(); i++){
-                Singleton.getInstance().addLogEntry(new LogEntry(counterList.get(i),LogType.RMV,0, counterList.get(i).getValue()));
+        if (counterList != null) {
+            for (int i = 0; i < counterList.size(); i++) {
+                Singleton.getInstance().addLogEntry(new LogEntry(counterList.get(i), LogType.RMV, 0, counterList.get(i).getValue()));
             }
         }
 
@@ -189,9 +191,9 @@ class CountersViewModel extends AndroidViewModel {
 
     void resetAll() {
         List<Counter> counterList = counters.getValue();
-        if(counterList != null){
-            for(int i = 0; i < counterList.size(); i++){
-                Singleton.getInstance().addLogEntry(new LogEntry(counterList.get(i),LogType.RST,0, counterList.get(i).getValue()));
+        if (counterList != null) {
+            for (int i = 0; i < counterList.size(); i++) {
+                Singleton.getInstance().addLogEntry(new LogEntry(counterList.get(i), LogType.RST, 0, counterList.get(i).getValue()));
             }
         }
 
@@ -217,11 +219,10 @@ class CountersViewModel extends AndroidViewModel {
     }
 
     private String getNextColor() {
-        if (listSize < colors.length) {
-            return colors[listSize];
+        if (nextCounterColor < colors.length) {
+            return colors[nextCounterColor];
         } else {
-            return colors[listSize % colors.length];
+            return colors[nextCounterColor % colors.length];
         }
-
     }
 }

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
@@ -66,6 +66,7 @@ class CountersViewModel extends AndroidViewModel {
                     }
                 });
         nextCounterColor++;
+        
     }
 
     void decreaseCounter(Counter counter) {

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
@@ -66,7 +66,6 @@ class CountersViewModel extends AndroidViewModel {
                     }
                 });
         nextCounterColor++;
-        
     }
 
     void decreaseCounter(Counter counter) {


### PR DESCRIPTION
I am done with this issue. The problem was that the Name of counter, especially the number, was getting automatically from DB and there was a problem.
e.g. when you deleted the counter with number 7 and the last one in view is number 8, next created counter will be allocated as counter number 8 and colour of counter is getting from the last created counter. If you deleted more than 1 counter, colour was still getting value from last one creating. 

I just added new variable for this fix. 

Now, when you delete some counter, the queue of colors will continue and the Value of counter is right. When you delete counter with number 7 and last in view is with number 8. the new counter have value 9 and another color as last one. I think, this problem is solved. 