### PR TITLE
Added ability to re-order counters 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,18 @@ gen-external-apklibs
 # End of https://www.gitignore.io/api/android
 
 .DS_Store
+
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties

--- a/.gitignore
+++ b/.gitignore
@@ -70,18 +70,3 @@ gen-external-apklibs
 # End of https://www.gitignore.io/api/android
 
 .DS_Store
-
-.gradle
-/build/
-
-# Ignore Gradle GUI config
-gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
-
-# Cache of project
-.gradletasknamecache
-
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,120 +1,33 @@
-apply plugin: 'com.android.application'
-apply plugin: 'io.fabric'
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-ext.versionMajor = 4
-ext.versionMinor = 3
-ext.versionPatch = 0
-ext.postfix = ''
-
-android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
-
-    defaultConfig {
-        applicationId 'ua.napps.scorekeeper'
-        minSdkVersion 19
-        targetSdkVersion 28
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables.useSupportLibrary = true
-        versionCode generateVersionCode()
-        versionName generateVersionName()
-        resConfigs "en", "ru", "uk", "fr", "de", "es"
-
-        manifestPlaceholders += [
-                crashlyticsEnabled: false
-        ]
-    }
-
-//    signingConfigs {
-//        release {
-//            storeFile new File(STORE_FILE)
-//            storePassword STORE_PASSWORD
-//            keyAlias KEY_ALIAS
-//            keyPassword KEY_PASSWORD
-//        }
-//    }
-
-    buildTypes {
-        debug {
-            useProguard false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-           // signingConfig signingConfigs.release
+buildscript {
+    repositories {
+        google()
+        jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
         }
 
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-//            signingConfig signingConfigs.release
-            manifestPlaceholders += [crashlyticsEnabled: true]
-        }
     }
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.google.gms:google-services:4.1.0'
+        classpath 'io.fabric.tools:gradle:1.26.1'
     }
 }
 
-dependencies {
-    implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
-    implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    implementation 'androidx.room:room-runtime:2.1.0-alpha01'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
-    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
-    implementation 'com.google.firebase:firebase-core:16.0.4'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
-        transitive = true
-    }
-    implementation('com.github.fernandodev.easyratingdialog:easyratingdialog:1.1.2') {
-        exclude module: 'material-dialogs'
-    }
-    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
-    implementation 'com.jakewharton.timber:timber:4.7.1'
-    implementation 'com.ashokvarma.android:bottom-navigation-bar:2.0.5'
-
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
-
-    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
-    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha01'
+plugins {
+    id 'com.github.ben-manes.versions' version '0.20.0'
 }
 
-configurations.all {
-    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        def requested = details.requested
-        if (requested.group == 'com.android.support') {
-            if (!requested.name.startsWith("multidex")) {
-                details.useVersion "$supportLibraryVersion"
-            }
-        }
+allprojects {
+    repositories {
+        jcenter()
+        google()
+        maven { url "https://dl.bintray.com/drummer-aidan/maven/" }
     }
 }
 
-def generateVersionCode() {
-    return ext.versionMajor * 10000 + ext.versionMinor * 100 + ext.versionPatch
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }
-
-def generateVersionName() {
-    return "${ext.versionMajor}.${ext.versionMinor}.${ext.versionPatch}${ext.postfix}"
-}
-
-task _printVersion << {
-    println "\n==================================================================================="
-    println "VERSION CODE: " + generateVersionCode()
-    println "===================================================================================\n"
-}
-
-task _printVersionName << {
-    println "\n==================================================================================="
-    println "VERSION NAME: " + generateVersionName()
-    println "===================================================================================\n"
-}
-
-apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,33 +1,120 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+apply plugin: 'com.android.application'
+apply plugin: 'io.fabric'
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-        maven {
-            url 'https://maven.fabric.io/public'
+ext.versionMajor = 4
+ext.versionMinor = 3
+ext.versionPatch = 0
+ext.postfix = ''
+
+android {
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
+
+    defaultConfig {
+        applicationId 'ua.napps.scorekeeper'
+        minSdkVersion 19
+        targetSdkVersion 28
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
+        versionCode generateVersionCode()
+        versionName generateVersionName()
+        resConfigs "en", "ru", "uk", "fr", "de", "es"
+
+        manifestPlaceholders += [
+                crashlyticsEnabled: false
+        ]
+    }
+
+    signingConfigs {
+        release {
+            storeFile new File(STORE_FILE)
+            storePassword STORE_PASSWORD
+            keyAlias KEY_ALIAS
+            keyPassword KEY_PASSWORD
+        }
+    }
+
+    buildTypes {
+        debug {
+            useProguard false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
 
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
+            manifestPlaceholders += [crashlyticsEnabled: true]
+        }
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:4.1.0'
-        classpath 'io.fabric.tools:gradle:1.26.1'
-    }
-}
-
-plugins {
-    id 'com.github.ben-manes.versions' version '0.20.0'
-}
-
-allprojects {
-    repositories {
-        jcenter()
-        google()
-        maven { url "https://dl.bintray.com/drummer-aidan/maven/" }
+    compileOptions {
+        targetCompatibility 1.8
+        sourceCompatibility 1.8
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
+dependencies {
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
+    implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.room:room-runtime:2.1.0-alpha01'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
+    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
+    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
+    implementation 'com.google.firebase:firebase-core:16.0.4'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
+        transitive = true
+    }
+    implementation('com.github.fernandodev.easyratingdialog:easyratingdialog:1.1.2') {
+        exclude module: 'material-dialogs'
+    }
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
+    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.ashokvarma.android:bottom-navigation-bar:2.0.5'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
+    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha01'
 }
+
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        def requested = details.requested
+        if (requested.group == 'com.android.support') {
+            if (!requested.name.startsWith("multidex")) {
+                details.useVersion "$supportLibraryVersion"
+            }
+        }
+    }
+}
+
+def generateVersionCode() {
+    return ext.versionMajor * 10000 + ext.versionMinor * 100 + ext.versionPatch
+}
+
+def generateVersionName() {
+    return "${ext.versionMajor}.${ext.versionMinor}.${ext.versionPatch}${ext.postfix}"
+}
+
+task _printVersion << {
+    println "\n==================================================================================="
+    println "VERSION CODE: " + generateVersionCode()
+    println "===================================================================================\n"
+}
+
+task _printVersionName << {
+    println "\n==================================================================================="
+    println "VERSION NAME: " + generateVersionName()
+    println "===================================================================================\n"
+}
+
+apply plugin: 'com.google.gms.google-services'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,27 +25,27 @@ android {
         ]
     }
 
-//    signingConfigs {
-//        release {
-//            storeFile new File(STORE_FILE)
-//            storePassword STORE_PASSWORD
-//            keyAlias KEY_ALIAS
-//            keyPassword KEY_PASSWORD
-//        }
-//    }
+    signingConfigs {
+        release {
+            storeFile new File(STORE_FILE)
+            storePassword STORE_PASSWORD
+            keyAlias KEY_ALIAS
+            keyPassword KEY_PASSWORD
+        }
+    }
 
     buildTypes {
         debug {
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            //signingConfig signingConfigs.release
+            signingConfig signingConfigs.release
         }
 
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            //signingConfig signingConfigs.release
+            signingConfig signingConfigs.release
             manifestPlaceholders += [crashlyticsEnabled: true]
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,27 +25,27 @@ android {
         ]
     }
 
-    signingConfigs {
-        release {
-            storeFile new File(STORE_FILE)
-            storePassword STORE_PASSWORD
-            keyAlias KEY_ALIAS
-            keyPassword KEY_PASSWORD
-        }
-    }
+//    signingConfigs {
+//        release {
+//            storeFile new File(STORE_FILE)
+//            storePassword STORE_PASSWORD
+//            keyAlias KEY_ALIAS
+//            keyPassword KEY_PASSWORD
+//        }
+//    }
 
     buildTypes {
         debug {
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+           // signingConfig signingConfigs.release
         }
 
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
             manifestPlaceholders += [crashlyticsEnabled: true]
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,32 +58,32 @@ android {
 dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.vectordrawable:vectordrawable:1.0.1'
     implementation 'androidx.dynamicanimation:dynamicanimation:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    implementation 'androidx.room:room-runtime:2.1.0-alpha01'
+    implementation 'androidx.room:room-runtime:2.1.0-alpha02'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha2'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
-    implementation 'com.google.firebase:firebase-core:16.0.4'
-    implementation('com.crashlytics.sdk.android:crashlytics:2.9.5@aar') {
+    implementation 'com.google.firebase:firebase-core:16.0.5'
+    implementation('com.crashlytics.sdk.android:crashlytics:2.9.6@aar') {
         transitive = true
     }
     implementation('com.github.fernandodev.easyratingdialog:easyratingdialog:1.1.2') {
         exclude module: 'material-dialogs'
     }
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.0'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.3'
     implementation 'com.jakewharton.timber:timber:4.7.1'
-    implementation 'com.ashokvarma.android:bottom-navigation-bar:2.0.5'
+    implementation 'com.ashokvarma.android:bottom-navigation-bar:2.1.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
 
     annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
-    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha01'
+    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha02'
 }
 
 configurations.all {
@@ -105,16 +105,5 @@ def generateVersionName() {
     return "${ext.versionMajor}.${ext.versionMinor}.${ext.versionPatch}${ext.postfix}"
 }
 
-task _printVersion << {
-    println "\n==================================================================================="
-    println "VERSION CODE: " + generateVersionCode()
-    println "===================================================================================\n"
-}
-
-task _printVersionName << {
-    println "\n==================================================================================="
-    println "VERSION NAME: " + generateVersionName()
-    println "===================================================================================\n"
-}
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/androidTest/java/ua/napps/scorekeeper/storage/DatabaseHolderTest.java
+++ b/app/src/androidTest/java/ua/napps/scorekeeper/storage/DatabaseHolderTest.java
@@ -33,7 +33,7 @@ public class DatabaseHolderTest {
 
     @Test
 public void insertDeleteAndCount() {
-    final Counter counter = new Counter("Counter", "#2196F3");
+    final Counter counter = new Counter("Counter", "#2196F3",0);
 
     assertThat(database.countersDao().count(), Is.is(0));
             database.countersDao().insert(counter);

--- a/app/src/main/java/ua/napps/scorekeeper/counters/Counter.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/Counter.java
@@ -20,9 +20,12 @@ public class Counter {
 
     private int value;
 
-    public Counter(@NonNull String name, String color) {
+    private int position;
+
+    public Counter(@NonNull String name, String color, int position) {
         this.name = name;
         this.color = color;
+        this.position = position;
         value = 0;
         defaultValue = 0;
         step = 1;
@@ -31,10 +34,19 @@ public class Counter {
     public Counter(Counter counter) {
         id = counter.id;
         this.name = counter.name;
-        color = counter.color;
-        value = counter.value;
+        this.color = counter.color;
+        this.value = counter.value;
+        this.position = counter.position;
         defaultValue = counter.defaultValue;
         step = counter.step;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
     }
 
     public String getColor() {
@@ -87,11 +99,12 @@ public class Counter {
 
     @Override
     public String toString() {
-        return "Counter{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", value=" + value + '}';
+        return "Counter{" + "id='" + id + '\'' + ", name='" + name + '\'' + ", value=" + value + '\'' + ", position=" + position + '}';
     }
 
+
     /**
-     * Checks if two counters are equal, uses id, color and name (id would suffice but this way it safer)
+     * Checks if two counters are equal, uses id, color, name and position (id would suffice but this way it safer)
      * @param other - {@link Object } to compare to
      * @return {@link Boolean} if equal or not
      */
@@ -107,6 +120,6 @@ public class Counter {
             return false;
         }
         Counter counter = (Counter) other;
-        return this.id == counter.id && this.name.equals(counter.name);
+        return this.id == counter.id && this.name.equals(counter.name) && this.position == counter.position;
     }
 }

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersDao.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersDao.java
@@ -21,13 +21,13 @@ public interface CountersDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(Counter counter);
 
-    @Query("SELECT * FROM counters")
+    @Query("SELECT * FROM counters ORDER BY position")
     LiveData<List<Counter>> loadAllCounters();
 
-    @Query("SELECT * FROM counters")
+    @Query("SELECT * FROM counters ORDER BY position")
     List<Counter> loadAllCountersSync();
 
-     @Query("SELECT COUNT(*) FROM counters")
+    @Query("SELECT COUNT(*) FROM counters")
     int count();
 
     @Query("select * from counters where id = :counterId")
@@ -50,6 +50,9 @@ public interface CountersDao {
 
     @Query("UPDATE counters SET value =(value +:difference) WHERE id ==:counterId")
     void modifyValue(int counterId, int difference);
+
+    @Query("UPDATE counters " + "SET position = :position WHERE id = :counterId")
+    void modifyPosition(int counterId, int position);
 
     @Query("UPDATE counters " + "SET value = defaultValue")
     void resetValues();

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersFragment.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersFragment.java
@@ -163,6 +163,17 @@ public class CountersFragment extends Fragment implements CounterActionCallback,
         final Context context = getContext();
         viewModel.getCounters().observe(this, counters -> {
             if (counters != null) {
+                boolean databaseVersionMigration = true;
+                for (Counter counter : counters) {
+                    if (counters.size() > 1 && counter.getPosition() != 0){
+                        databaseVersionMigration = false;
+                    }
+                }
+                if (databaseVersionMigration) {
+                    for (int i = 0; i < counters.size(); i++) {
+                        viewModel.setPositionAfterDBMigration(counters.get(i), i);
+                    }
+                }
                 final int size = counters.size();
                 viewModel.setListSize(size);
                 emptyState.setVisibility(size > 0 ? View.GONE : View.VISIBLE);

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersRepository.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersRepository.java
@@ -16,10 +16,10 @@ class CountersRepository {
         this.countersDao = countersDao;
     }
 
-    public Completable createCounter(String name, String color) {
+    public Completable createCounter(String name, String color, int position) {
 
         return Completable.fromAction(() -> {
-            final Counter counter = new Counter(name, color);
+            final Counter counter = new Counter(name, color,position);
             countersDao.insert(counter);
         });
     }
@@ -58,6 +58,10 @@ class CountersRepository {
 
     public Completable modifyStep(int counterId, int step) {
         return Completable.fromAction(() -> countersDao.modifyStep(counterId, step));
+    }
+
+    public Completable modifyPosition(int counterId, int position) {
+        return Completable.fromAction(() -> countersDao.modifyPosition(counterId,position));
     }
 
     public Completable resetAll() {

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
@@ -158,6 +158,27 @@ class CountersViewModel extends AndroidViewModel {
     }
 
 
+    void setPositionAfterDBMigration(Counter counter, int position){
+        repository.modifyPosition(counter.getId(), position)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribe(new CompletableObserver() {
+                    @Override
+                    public void onComplete() {
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        Timber.e(e, "modifyPosition counter");
+                    }
+
+                    @Override
+                    public void onSubscribe(Disposable d) {
+
+                    }
+                });
+    }
+
     void modifyPosition(Counter counter, int fromPosition, int toPosition) {
         if (fromPosition == toPosition) {
             return;

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersViewModel.java
@@ -46,7 +46,7 @@ class CountersViewModel extends AndroidViewModel {
     }
 
     void addCounter() {
-        repository.createCounter(String.valueOf(listSize + 1), getNextColor())
+        repository.createCounter(String.valueOf(listSize + 1), getNextColor(), listSize)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribeOn(Schedulers.io())
                 .subscribe(new CompletableObserver() {
@@ -155,6 +155,82 @@ class CountersViewModel extends AndroidViewModel {
 
                     }
                 });
+    }
+
+
+    void modifyPosition(Counter counter, int fromPosition, int toPosition) {
+        if (fromPosition == toPosition) {
+            return;
+        }
+
+        if (toPosition == counter.getPosition()) {
+            return;
+        }
+
+        if (toPosition > counters.getValue().size() - 1) {
+            toPosition = counters.getValue().size() - 1;
+        }
+
+        Bundle params = new Bundle();
+        params.putString(Param.CHARACTER, "" + toPosition);
+        AndroidFirebaseAnalytics.logEvent("counter_position_change", params);
+
+        int smallerIndex = Math.min(fromPosition, toPosition);
+        int largerIndex = Math.max(fromPosition, toPosition);
+        int moveStep;
+
+        if (toPosition > fromPosition) {
+            moveStep = -1;
+        } else {
+            moveStep = 1;
+        }
+
+        List<Counter> counterList = counters.getValue();
+        if (counterList != null) {
+            for (int i = 0; i < counterList.size(); i++) {
+                if (counterList.get(i).getId() == counter.getId()) {
+                    repository.modifyPosition(counter.getId(), toPosition)
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribeOn(Schedulers.io())
+                            .subscribe(new CompletableObserver() {
+                                @Override
+                                public void onComplete() {
+
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    Timber.e(e, "modifyPosition counter");
+                                }
+
+                                @Override
+                                public void onSubscribe(Disposable d) {
+
+                                }
+                            });
+                } else if (counterList.get(i).getPosition() >= smallerIndex && counterList.get(i).getPosition() <= largerIndex) {
+                    repository.modifyPosition(counterList.get(i).getId(), counterList.get(i).getPosition() + moveStep)
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribeOn(Schedulers.io())
+                            .subscribe(new CompletableObserver() {
+                                @Override
+                                public void onComplete() {
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    Timber.e(e, "modifyPosition counter");
+                                }
+
+                                @Override
+                                public void onSubscribe(Disposable d) {
+
+                                }
+                            });
+                }
+            }
+        }
+
     }
 
 

--- a/app/src/main/java/ua/napps/scorekeeper/counters/ItemDragAdapter.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/ItemDragAdapter.java
@@ -1,0 +1,9 @@
+package ua.napps.scorekeeper.counters;
+
+public interface ItemDragAdapter {
+
+    void onItemMove(int fromPosition, int toPosition);
+
+    void onItemClear(int fromPosition, int toPosition);
+
+}

--- a/app/src/main/java/ua/napps/scorekeeper/counters/ItemDragHelperCallback.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/ItemDragHelperCallback.java
@@ -1,0 +1,93 @@
+package ua.napps.scorekeeper.counters;
+
+import android.graphics.Canvas;
+
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class ItemDragHelperCallback extends ItemTouchHelper.Callback{
+
+
+    private final ItemDragAdapter itemDragAdapter;
+    private Integer lastFrom = null;
+    private Integer lastTo = null;
+
+    public ItemDragHelperCallback(ItemDragAdapter itemDragAdapter) {
+        this.itemDragAdapter = itemDragAdapter;
+    }
+
+    @Override
+    public boolean isLongPressDragEnabled() {
+        // We will start drag event manually
+        return false;
+    }
+
+    @Override
+    public boolean isItemViewSwipeEnabled() {
+        // Swiping not used
+        return false;
+    }
+
+
+    @Override
+    public int getMovementFlags(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+        final int dragFlags = ItemTouchHelper.UP   | ItemTouchHelper.DOWN |
+                ItemTouchHelper.LEFT | ItemTouchHelper.RIGHT;
+        return makeMovementFlags(dragFlags, 0);
+    }
+
+
+    @Override
+    public boolean onMove(RecyclerView recyclerView, RecyclerView.ViewHolder source, RecyclerView.ViewHolder target) {
+        // Called during dragging event
+        if (source.getItemViewType() != target.getItemViewType()) {
+            return false;
+        }
+        if (lastFrom == null) {
+            lastFrom = source.getAdapterPosition();
+        }
+        lastTo = target.getAdapterPosition();
+        itemDragAdapter.onItemMove(source.getAdapterPosition(), target.getAdapterPosition());
+        return false;
+    }
+
+    @Override
+    public void onChildDraw(Canvas c, RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive) {
+        //Do not allow dragging items out of bounds
+        float topY = viewHolder.itemView.getTop() + dY;
+        float bottomY = topY + viewHolder.itemView.getHeight();
+        if (topY < 0) {
+            dY = 0;
+        } else if (bottomY > recyclerView.getHeight()) {
+            dY = recyclerView.getHeight() - viewHolder.itemView.getHeight() - viewHolder.itemView.getTop();
+        }
+
+        float minX = viewHolder.itemView.getLeft() + dX;
+        float maxX = minX + viewHolder.itemView.getWidth();
+        if (minX < 0) {
+            dX = 0;
+        } else if (maxX > recyclerView.getWidth()) {
+            dX = recyclerView.getWidth() - viewHolder.itemView.getWidth() - viewHolder.itemView.getLeft();
+        }
+        super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+    }
+
+    @Override
+    public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+        // Called after dragging event, when item is released
+        super.clearView(recyclerView, viewHolder);
+
+        if (lastFrom != null && lastTo != null) {
+            itemDragAdapter.onItemClear(lastFrom, lastTo);
+        }
+        lastFrom = null;
+        lastTo = null;
+    }
+
+    @Override
+    public void onSwiped(RecyclerView.ViewHolder viewHolder, int i) {
+       // No action when swiped
+    }
+
+
+}

--- a/app/src/main/java/ua/napps/scorekeeper/listeners/DragItemListener.java
+++ b/app/src/main/java/ua/napps/scorekeeper/listeners/DragItemListener.java
@@ -1,0 +1,12 @@
+package ua.napps.scorekeeper.listeners;
+
+
+import androidx.recyclerview.widget.RecyclerView;
+import ua.napps.scorekeeper.counters.Counter;
+
+public interface DragItemListener {
+
+    void onStartDrag(RecyclerView.ViewHolder viewHolder);
+
+    void afterDrag(Counter counter, int fromPosition, int toPosition);
+}

--- a/app/src/main/java/ua/napps/scorekeeper/storage/DatabaseHolder.java
+++ b/app/src/main/java/ua/napps/scorekeeper/storage/DatabaseHolder.java
@@ -12,7 +12,7 @@ import androidx.annotation.NonNull;
 import ua.napps.scorekeeper.counters.Counter;
 import ua.napps.scorekeeper.counters.CountersDao;
 
-@Database(entities = {Counter.class}, version = 2, exportSchema = false)
+@Database(entities = {Counter.class}, version = 3, exportSchema = false)
 public abstract class DatabaseHolder extends RoomDatabase {
 
     private static DatabaseHolder database;
@@ -25,7 +25,7 @@ public abstract class DatabaseHolder extends RoomDatabase {
     @MainThread
     public static void init(@NonNull Context context) {
         database = Room.databaseBuilder(context.getApplicationContext(), DatabaseHolder.class, "counters-database")
-                .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .fallbackToDestructiveMigration()
                 .build();
     }
@@ -39,4 +39,12 @@ public abstract class DatabaseHolder extends RoomDatabase {
         // Since we didn't alter the table, there's nothing else to do here.
     }
 };
+
+    static final Migration MIGRATION_2_3 = new Migration(2, 3) {
+        @Override
+        public void migrate(SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE counters "
+                    + " ADD COLUMN position INTEGER NOT NULL DEFAULT 0");
+        }
+    };
 }

--- a/app/src/main/res/layout-land/activity_edit_counter.xml
+++ b/app/src/main/res/layout-land/activity_edit_counter.xml
@@ -223,6 +223,52 @@
                     app:srcCompat="@drawable/ic_information" />
             </LinearLayout>
 
+            <LinearLayout
+                android:id="@+id/counter_position"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center_horizontal"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    android:padding="@dimen/spacing_normal">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center"
+                        android:minLines="2"
+                        android:text="@string/counter_details_position"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:id="@+id/tv_counter_position"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+                        android:textColor="?android:attr/textColorPrimary"
+                        tools:text="0" />
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/iv_position_info"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="end|center_vertical"
+                    android:contentDescription="@string/common_info"
+                    android:padding="@dimen/spacing_normal"
+                    android:scaleType="center"
+                    app:srcCompat="@drawable/ic_information" />
+            </LinearLayout>
+
+
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/layout/activity_edit_counter.xml
+++ b/app/src/main/res/layout/activity_edit_counter.xml
@@ -204,6 +204,54 @@
                     android:scaleType="center"
                     app:srcCompat="@drawable/ic_information" />
             </FrameLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="?myDividerColor"
+                android:layout_marginStart="@dimen/keyline_1" />
+
+            <FrameLayout
+                android:id="@+id/counter_position"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    style="@style/SingleLineStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingBottom="@dimen/spacing_normal"
+                    android:paddingStart="@dimen/keyline_1"
+                    android:paddingTop="@dimen/spacing_normal">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/counter_details_position"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+                    <TextView
+                        android:id="@+id/tv_counter_position"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+                        tools:text="0" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/iv_position_info"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:layout_gravity="end|center_vertical"
+                    android:layout_marginEnd="@dimen/spacing_normal"
+                    android:contentDescription="@string/common_info"
+                    android:padding="@dimen/spacing_normal"
+                    android:scaleType="center"
+                    app:srcCompat="@drawable/ic_information" />
+
+            </FrameLayout>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -61,4 +61,8 @@
     <string name="dialog_confirmation_question">Are you sure?</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>
+    <string name="counter_details_position">Position</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -54,4 +54,15 @@
     <string name="menu_log">Historial</string>
     <string name="log_counter">Contador:</string>
     <string name="history_empty_message">No hay historial aún</string>
+    <string name="counter_details_position">Position</string>
+    <string name="dialog_yes">Yes</string>
+    <string name="dialog_no">No</string>
+    <string name="common_counter">Counter</string>
+    <string name="dialog_custom_counter_title">Custom counter value</string>
+    <string name="dialog_custom_counter_hint">From 2 to 999</string>
+    <string name="settings_section_counter_buttons">Set the value of the buttons in a counter dialog (by a long press)</string>
+    <string name="dialog_confirmation_question">Are you sure?</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -61,4 +61,8 @@
     <string name="dialog_confirmation_question">Are you sure?</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>
+    <string name="counter_details_position">Position</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -61,4 +61,8 @@
     <string name="dialog_confirmation_question">Are you sure?</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>
+    <string name="counter_details_position">Position</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -61,4 +61,8 @@
     <string name="dialog_confirmation_question">Are you sure?</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>
+    <string name="counter_details_position">Position</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,8 @@
     <string name="dialog_confirmation_question">Are you sure?</string>
     <string name="dialog_yes">Yes</string>
     <string name="dialog_no">No</string>
+    <string name="counter_details_position">Position</string>
+    <string name="counter_position_zero">Position cannot be zero.</string>
+    <string name="counter_position_current">You entered current position of the counter.</string>
+    <string name="dialog_position_info_content">Position of given counter in the list. Must be higher than 0. If you set position higher than current number of counters, counter will be moved to the end of list.</string>
 </resources>


### PR DESCRIPTION
I added reordering mechanism for counter’s recycler view. When you long press counter’s header, you can drag counter to new position within recycler view.
You can also change counter position from counter’s details screen by specifying new position through a dialog window.
I changed database handling (added field position), repository and view models for both CountersFragment and EditCounterActivity.
Items dragging is handled by extending ItemTouchHelper.Callback class. During dragging event items are moved within CountersAdapter and only after the event, changes are populated to the database.
I spend many hours trying to fix issue during dragging. When item was moved to the top of recycler view with two grid columns, it was placed above the bound of recycler view and that generated many other problems. When I finally tried changing staggeredgridlayoutmanager to basic gridlayoutmanager mentioned problems have disappeared.
