### PR TITLE
Added ability to change number of full counters

### DIFF
--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersAdapter.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersAdapter.java
@@ -29,6 +29,7 @@ import java.util.TimerTask;
 
 import ua.napps.scorekeeper.R;
 import ua.napps.scorekeeper.listeners.DragItemListener;
+import ua.napps.scorekeeper.settings.LocalSettings;
 import ua.napps.scorekeeper.utils.ColorUtil;
 
 public class CountersAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements ItemDragAdapter {
@@ -109,7 +110,7 @@ public class CountersAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     @Override
     public int getItemViewType(int position) {
-        if (getItemCount() < 6) {
+        if (getItemCount() <= LocalSettings.getNumberOfFullCounters()) {
             return TYPE_FULL;
         } else {
             return TYPE_COMPACT;

--- a/app/src/main/java/ua/napps/scorekeeper/counters/CountersFragment.java
+++ b/app/src/main/java/ua/napps/scorekeeper/counters/CountersFragment.java
@@ -229,7 +229,7 @@ public class CountersFragment extends Fragment implements CounterActionCallback,
 
                 if (oldListSize != size) {
                     countersAdapter.notifyDataSetChanged();
-                    if (size < 6) {
+                    if (size <= LocalSettings.getNumberOfFullCounters()) {
                         recyclerView.setLayoutManager(new SpanningLinearLayoutManager(requireContext()));
                     } else {
                         recyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));

--- a/app/src/main/java/ua/napps/scorekeeper/settings/LocalSettings.java
+++ b/app/src/main/java/ua/napps/scorekeeper/settings/LocalSettings.java
@@ -15,6 +15,7 @@ public class LocalSettings {
     private static final String KEY_NEVER_REMINDER = "KEY_NEVER_REMINDER";
     private static final String IS_LOWEST_SCORE_WINS = "is_lowest_score_wins";
     private static final String IS_COUNTERS_VIBRATE = "is_counters_vibrate";
+    private static final String NUMBER_OF_FULL_COUNTERS = "number_of_full_counters";
 
     private static final String CUSTOM_COUNTER_1 = "custom_counter_1";
     private static final String CUSTOM_COUNTER_2 = "custom_counter_2";
@@ -141,5 +142,13 @@ public class LocalSettings {
 
     public static void saveCountersVibrate(boolean enabled) {
         App.getTinyDB().putBoolean(IS_COUNTERS_VIBRATE, enabled);
+    }
+
+    public static int getNumberOfFullCounters() {
+        return App.getTinyDB().getInt(NUMBER_OF_FULL_COUNTERS, 5);
+    }
+
+    public static void saveNumberOfFullCounters(int numberOfFullCounters) {
+        App.getTinyDB().putInt(NUMBER_OF_FULL_COUNTERS, numberOfFullCounters);
     }
 }

--- a/app/src/main/java/ua/napps/scorekeeper/settings/SettingsFragment.java
+++ b/app/src/main/java/ua/napps/scorekeeper/settings/SettingsFragment.java
@@ -33,7 +33,7 @@ import ua.napps.scorekeeper.utils.ViewUtil;
 
 public class SettingsFragment extends Fragment implements CompoundButton.OnCheckedChangeListener, View.OnClickListener {
 
-    private TextView btn_c_1, btn_c_2, btn_c_3, btn_c_4;
+    private TextView btn_c_1, btn_c_2, btn_c_3, btn_c_4, btn_num_full_counters;
 
     public SettingsFragment() {
         // Required empty public constructor
@@ -56,6 +56,8 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
         btn_c_2 = contentView.findViewById(R.id.btn_2_text);
         btn_c_3 = contentView.findViewById(R.id.btn_3_text);
         btn_c_4 = contentView.findViewById(R.id.btn_4_text);
+
+        btn_num_full_counters = contentView.findViewById(R.id.btn_full_counters);
 
         keepScreenOn.setChecked(LocalSettings.isKeepScreenOnEnabled());
         darkTheme.setChecked(!LocalSettings.isLightTheme());
@@ -80,6 +82,8 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
         btn_c_2.setOnClickListener(this);
         btn_c_3.setOnClickListener(this);
         btn_c_4.setOnClickListener(this);
+
+        btn_num_full_counters.setOnClickListener(this);
 
         btn_c_1.setText(String.valueOf(LocalSettings.getCustomCounter(1)));
         btn_c_2.setText(String.valueOf(LocalSettings.getCustomCounter(2)));
@@ -108,7 +112,7 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
             case R.id.sw_switch_vibrate:
                 LocalSettings.saveCountersVibrate(enabled);
                 if (enabled) {
-                    ViewUtil.shakeView(v,2,0);
+                    ViewUtil.shakeView(v, 2, 0);
                 }
                 break;
         }
@@ -134,22 +138,25 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
                 startActivity(viewIntent);
                 break;
             case R.id.btn_1_text:
-                openCustomCounterDialog(1, ((TextView) v).getText());
+                openNumberInputDialog("counter_btn_1", ((TextView) v).getText(), 1, 999);
                 break;
             case R.id.btn_2_text:
-                openCustomCounterDialog(2, ((TextView) v).getText());
+                openNumberInputDialog("counter_btn_2", ((TextView) v).getText(), 1, 999);
                 break;
             case R.id.btn_3_text:
-                openCustomCounterDialog(3, ((TextView) v).getText());
+                openNumberInputDialog("counter_btn_3", ((TextView) v).getText(), 1, 999);
                 break;
             case R.id.btn_4_text:
-                openCustomCounterDialog(4, ((TextView) v).getText());
+                openNumberInputDialog("counter_btn_4", ((TextView) v).getText(), 1, 999);
                 break;
             case R.id.tv_counter:
                 new MaterialDialog.Builder(requireActivity())
                         .content(R.string.settings_section_counter_buttons)
                         .positiveText(R.string.common_got_it)
                         .show();
+                break;
+            case R.id.btn_full_counters:
+                openNumberInputDialog("btn_num_full_counters", Integer.toString(LocalSettings.getNumberOfFullCounters()), 1, 15);
                 break;
             case R.id.tv_share:
                 Intent shareIntent = new Intent(Intent.ACTION_SEND);
@@ -165,17 +172,17 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
         }
     }
 
-    private void openCustomCounterDialog(final int id, CharSequence oldValue) {
+    private void openNumberInputDialog(final String setting, CharSequence oldValue, int minValue, int maxValue) {
         final MaterialDialog md = new MaterialDialog.Builder(requireActivity())
                 .content(R.string.dialog_custom_counter_title)
                 .inputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED)
                 .positiveText(R.string.common_set)
-                .contentColor(DialogUtils.getColor(requireContext(),R.color.textColorPrimary))
+                .contentColor(DialogUtils.getColor(requireContext(), R.color.textColorPrimary))
                 .alwaysCallInputCallback()
                 .input(oldValue, null, false,
                         (dialog, input) -> {
                             int parseInt = Utilities.parseInt(input.toString());
-                            if (parseInt <= 999 && parseInt > 1) {
+                            if (parseInt <= maxValue && parseInt > minValue) {
                                 dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
                             } else {
                                 dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
@@ -199,8 +206,8 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
                     if (editText != null) {
                         String value = editText.getText().toString();
                         Integer parseInt = Utilities.parseInt(value);
-                        if (parseInt <= 999 && parseInt > 1) {
-                            setCustomCounter(id, parseInt);
+                        if (parseInt <= maxValue && parseInt > minValue) {
+                            updateInputDialogSetting(setting, parseInt);
                         }
                         dialog.dismiss();
                     }
@@ -222,26 +229,33 @@ public class SettingsFragment extends Fragment implements CompoundButton.OnCheck
                 WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
     }
 
-    private void setCustomCounter(int id, int value) {
-        LocalSettings.saveCustomCounter(id, value);
+    private void updateInputDialogSetting(String id, int value) {
         switch (id) {
-            case 1:
+            case "counter_btn_1":
                 btn_c_1.setText(String.valueOf(value));
-                ViewUtil.shakeView(btn_c_1,4,0);
+                ViewUtil.shakeView(btn_c_1, 4, 0);
+                LocalSettings.saveCustomCounter(1, value);
                 break;
-            case 2:
+            case "counter_btn_2":
                 btn_c_2.setText(String.valueOf(value));
-                ViewUtil.shakeView(btn_c_2,4,0);
+                ViewUtil.shakeView(btn_c_2, 4, 0);
+                LocalSettings.saveCustomCounter(2, value);
                 break;
-            case 3:
+            case "counter_btn_3":
                 btn_c_3.setText(String.valueOf(value));
-                ViewUtil.shakeView(btn_c_3,4,0);
+                ViewUtil.shakeView(btn_c_3, 4, 0);
+                LocalSettings.saveCustomCounter(3, value);
                 break;
-            case 4:
+            case "counter_btn_4":
                 btn_c_4.setText(String.valueOf(value));
-                ViewUtil.shakeView(btn_c_4,4,0);
+                ViewUtil.shakeView(btn_c_4, 4, 0);
+                LocalSettings.saveCustomCounter(4, value);
+                break;
+            case "btn_num_full_counters":
+                LocalSettings.saveNumberOfFullCounters(value);
                 break;
         }
+
     }
 
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -166,6 +166,17 @@
 
         </LinearLayout>
 
+        <include layout="@layout/divider" />
+
+        <TextView
+            android:id="@+id/btn_full_counters"
+            style="@style/TwoLinesStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="@dimen/padding_large"
+            android:text="@string/settings_num_full_counters"
+            android:textAppearance="?attr/textAppearanceHeadline6" />
+
 
         <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,4 +85,5 @@
     <string name="translators">Übersetzung\n\ud83c\uddf7\ud83c\uddf4 Andrei Iacob\n\ud83c\uddf5\ud83c\uddf1 Osmine Retro, maiky\n\ud83c\uddea\ud83c\uddf8 ZVirus\n\ud83c\uddeb\ud83c\uddf7 Jumar</string>
     <string name="donation_xwing_title">Star Wars: X-Wing Miniaturen-Spiel</string>
     <string name="donation_xwing_description">Neue Miniaturen</string>
+    <string name="settings_num_full_counters">Anzahl großer Zähler</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,4 +89,5 @@
     <string name="common_vibrate">Vibrate</string>
     <string name="credits" translatable="false">Github\n☆ vabene1111\n☆ PeterCeresnik\n☆ 10matej15\n☆ drstranges\n☆ janethavi</string>
     <string name="translators">Translation\n\ud83c\uddf7\ud83c\uddf4 Andrei Iacob\n\ud83c\uddf5\ud83c\uddf1 Osmine Retro, maiky\n\ud83c\uddea\ud83c\uddf8 ZVirus\n\ud83c\uddeb\ud83c\uddf7 Jumar</string>
+    <string name="settings_num_full_counters">Number of large counters</string>
 </resources>


### PR DESCRIPTION
This PR adds a setting that allows to choose how many large counters should be displayed. 

- fixes #66
- Very useful for large devices 
- This can later be expanded with an automatic screen detection to automatically keep up with ever growing screen sizes

I also changed the inputDialog on the settings page to be somewhat generic in case any other number based settings should be added in the future, this introduces some very small overhead but reduces code overall as i did not need to create a secondary dialog with lots of duplicate code